### PR TITLE
Fix HTML bugs and add calculateHours tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/__tests__/calculateHours.test.js
+++ b/__tests__/calculateHours.test.js
@@ -1,0 +1,38 @@
+const { JSDOM } = require('jsdom');
+const { calculateHours } = require('../calculateHours');
+
+describe('calculateHours', () => {
+  function setupRow(start, end) {
+    const dom = new JSDOM(`<table><tr>
+      <td><input class="activity-start" value="${start}"></td>
+      <td><input class="activity-end" value="${end}"></td>
+      <td><input class="activity-hours"></td>
+    </tr></table>`);
+    const row = dom.window.document.querySelector('tr');
+    return { row, dom };
+  }
+
+  test('calculates normal difference', () => {
+    const { row } = setupRow('08:00', '10:15');
+    const start = row.querySelector('.activity-start');
+    calculateHours(start);
+    const hours = row.querySelector('.activity-hours').value;
+    expect(hours).toBe('2.5');
+  });
+
+  test('handles crossing midnight', () => {
+    const { row } = setupRow('22:00', '01:30');
+    const end = row.querySelector('.activity-end');
+    calculateHours(end);
+    const hours = row.querySelector('.activity-hours').value;
+    expect(hours).toBe('3.5');
+  });
+
+  test('rounds to nearest half hour', () => {
+    const { row } = setupRow('09:00', '09:20');
+    const end = row.querySelector('.activity-end');
+    calculateHours(end);
+    const hours = row.querySelector('.activity-hours').value;
+    expect(hours).toBe('0.5');
+  });
+});

--- a/calculateHours.js
+++ b/calculateHours.js
@@ -1,0 +1,23 @@
+function calculateHours(input) {
+    const row = input.closest('tr');
+    const startInput = row.querySelector('.activity-start');
+    const endInput = row.querySelector('.activity-end');
+    const hoursInput = row.querySelector('.activity-hours');
+
+    if (startInput.value && endInput.value) {
+        const start = new Date(`2000-01-01T${startInput.value}`);
+        const end = new Date(`2000-01-01T${endInput.value}`);
+
+        let diff = (end - start) / (1000 * 60 * 60); // Convert to hours
+
+        // Handle crossing midnight
+        if (diff < 0) {
+            diff += 24;
+        }
+
+        // Round to nearest 0.5
+        hoursInput.value = Math.round(diff * 2) / 2;
+    }
+}
+
+module.exports = { calculateHours };

--- a/index.html
+++ b/index.html
@@ -901,7 +901,7 @@
             <div class="section">
                 <h2>Pass Down Summary</h2>
                 <button type="button" class="btn btn-primary" onclick="loadTestData()" style="margin-bottom: 20px;">
-                    📊 Load Test Equipment Data (Simulates your 3,770 items)
+                    📊 Load sample equipment data
                 </button>
                 <div id="loadStatus" style="display: none; padding: 10px; background: #e3f2fd; border-radius: 4px; margin-bottom: 20px;">
                     <span id="loadingMessage">Loading equipment data...</span>
@@ -1926,8 +1926,14 @@
                             <input type="checkbox" id="check_${type}_${index}" class="equipment-check" data-equipment="${item}">
                             <label for="check_${type}_${index}">${item}</label>
                         `;
-                        checklistItems.appendChild(div);
-                    });
-                    
-                    document.getElementById('inspectionTypeDiv').style.display = 'none';
-                
+                    checklistItems.appendChild(div);
+                });
+
+                document.getElementById('inspectionTypeDiv').style.display = 'none';
+                checklistDiv.style.display = 'block';
+            }
+        }
+    }
+    </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mh-shift-report",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jsdom": "^21.1.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}


### PR DESCRIPTION
## Summary
- cleanup truncated HTML and re-add closing tags
- adjust label for loading sample data
- add calculateHours utility module
- add Jest test suite for calculateHours
- ignore node_modules and package-lock

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688054afec20832186f813ce233cae47